### PR TITLE
readme-cursor-smoke-test: README smoke test (OrgWave)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ To run, follow these steps:
 ![](https://github.com/sathish-dhana/Bath-Bodyworks/blob/465f9958423fce37e94c854aaefdfd802963ba94/pictures/shot-7.png)
 
 
+Updated by Cursor.


### PR DESCRIPTION
OrgWave playbook [readme-cursor-smoke-test](https://github.com/sathish-dhana/orgwave-playbooks/tree/main/playbooks/readme-cursor-smoke-test) — appends one line to `README.md` for a Cursor/GitHub smoke test.

Source catalog repo: https://github.com/sathish-dhana/orgwave-playbooks

**Do not merge** without review.
